### PR TITLE
Fix access to the userinfo

### DIFF
--- a/lib/passport-cloudfoundry/strategy.js
+++ b/lib/passport-cloudfoundry/strategy.js
@@ -88,6 +88,8 @@ function Strategy(options, verify) {
 
     //Set AuthMethod as 'Bearer' (used w/ accessToken to perform actual resource actions)
     this._oauth2.setAuthMethod('Bearer');
+    //Make sure that it is used when performing a userinfo request:
+    this._oauth2.useAuthorizationHeaderforGET(true);
 
     //Set default userProfileURI (this is /info endpoint for cloudfoundry.COM)
     this._userProfileURI = 'https://uaa.cloudfoundry.com/userinfo';


### PR DESCRIPTION
Hi Raja!
Thanks for contributing this project.
Here is a small tweak for it.

Cheers!

passport-cloudfoundry fails to load the user profile from uaa.
uaa refuses to serve the /userinfo requests to passport-cloudfoundry
it redirects to the login view as the access token is not set in the
headers.

node-oauth will not add the accesstoken to the headers
when it performs a GET request unless the method
useAuthorizationHeaderforGET has been called.

This is the case for the versions of node-oauth installed by
the current version of passport-oauth (1.1.15)
and the earlier versions used by passport-cloudfoundry (0.1.x)
